### PR TITLE
Update BioJulia link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Package suites gather software packages and installation tools for specific lang
 
 ### BioJulia
 
-* __[BioJulia](http://biojulia.net/Bio.jl/)__ - Bioinformatics and computational biology infastructure for the Julia programming language.
+* __[BioJulia](https://biojulia.net/)__ - Bioinformatics and computational biology infastructure for the Julia programming language.
 
 ## Data Tools
 


### PR DESCRIPTION
The old link points to the now-archived Bio.jl, the new link points to the organisation home page.