### PR TITLE
Add proteinflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of awesome Bioinformatics software, resources, and libraries. Mos
   - [Compressing](#compressing)
 - [Data Processing](#data-processing)
   - [Command Line Utilities](#command-line-utilities)
+  - [Python Modules](#python-modules)
 - [Next Generation Sequencing](#next-generation-sequencing)
   - [Workflow Managers](#workflow-managers)
   - [Pipelines](#pipelines)
@@ -102,6 +103,9 @@ Package suites gather software packages and installation tools for specific lang
 - **[tabix](https://github.com/samtools/tabix)** - Table file index. [ [paper-2011](https://pubmed.ncbi.nlm.nih.gov/21208982) ]
 - **[wormtable](https://github.com/wormtable/wormtable)** - Write-once-read-many table for large datasets.
 - **[zindex](https://github.com/mattgodbolt/zindex)** - Create an index on a compressed text file.
+
+### Python Modules
+- **[proteinflow](https://github.com/adaptyvbio/ProteinFlow)** - A processing pipeline for using PDB data in AI model training
 
 ## Next Generation Sequencing
 


### PR DESCRIPTION
Adding a link `proteinflow` to the data processing section. It's a python library for processing and standardizing protein structure data from PDB (mostly for protein design AI applications).