### PR TITLE
add: BioArchLinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Package suites gather software packages and installation tools for specific lang
 
 - **[Bioconda](https://github.com/bioconda)** - A channel for the [conda package manager](http://conda.pydata.org/docs/intro.html) specializing in bioinformatics software. Includes a repository with 3000+ ready-to-install (with `conda install`) bioinformatics packages. [ [paper-2018](https://pubmed.ncbi.nlm.nih.gov/29967506) | [web](https://bioconda.github.io) ]
 
+- **[BioArchLinux](https://github.com/BioArchLinux)** - A [bioinformatics software repository](https://github.com/BioArchLinux/Packages) for [Arch Linux](https://archlinux.org) users with newer and more packages. Users can install a growing list (current 4,300+) of compiled packages via `pacman -S foo`. [ [paper-2022](https://doi.org/10.7490/f1000research.1119039.1) | [web](https://bioarchlinux.org) ]
+
 - **[BioJulia](https://github.com/BioJulia)** - Bioinformatics and computational biology infastructure for the Julia programming language. [ [web](https://biojulia.net) ]
 - **[Rust-Bio](https://github.com/rust-bio/rust-bio)** - Rust implementations of algorithms and data structures useful for bioinformatics. [ [paper-2016](http://bioinformatics.oxfordjournals.org/content/early/2015/10/06/bioinformatics.btv573.short?rss=1) ]
 - **[SeqAn](https://github.com/seqan/seqan3)** - The modern C++ library for sequence analysis.


### PR DESCRIPTION
BioArchLinux is useful if users choose Arch Linux as their Linux distribution. Contribution is simple and logical, every stage of complying pkg is based on single shell function. After easy-to-understand lilac.yaml configuration, the pkg can be auto upgraded.