### PR TITLE
Add Runcell AI Agent to tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The following items allow for scalable genomic analysis by introducing specializ
 - **[pyfaidx](https://github.com/mdshw5/pyfaidx)** - Pythonic access to FASTA files.
 - **[pysam](https://github.com/pysam-developers/pysam)** - Python wrapper for [samtools](https://github.com/samtools/samtools). [ [web](https://pysam.readthedocs.io/en/latest/api.html) ]
 - **[pyVCF](https://github.com/jamescasbon/PyVCF)** - A VCF Parser for Python. [ [web](http://pyvcf.readthedocs.org/en/latest/index.html) ]
+- **[Runcell](https://www.runcell.dev)** - AI Agent In Jupyter Lab, assist with coding, debuging, analysis, etc.
 
 ### Assembly
 - **[SPAdes](https://github.com/ablab/spades)** - SPAdes (St. Petersburg genome assembler) is an assembly toolkit containing various assembly pipelines and the de-facto standard for prokaryotic genome assemblies.


### PR DESCRIPTION
Add AI Agent tool for Jupyter Lab.

It can be used with simple `pip install runcell`, and bring agentic features to jupyter lab.