### PR TITLE
Add ClawBio — bioinformatics AI agent skill library

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The following items allow for scalable genomic analysis by introducing specializ
 - **[pyfaidx](https://github.com/mdshw5/pyfaidx)** - Pythonic access to FASTA files.
 - **[pysam](https://github.com/pysam-developers/pysam)** - Python wrapper for [samtools](https://github.com/samtools/samtools). [ [web](https://pysam.readthedocs.io/en/latest/api.html) ]
 - **[pyVCF](https://github.com/jamescasbon/PyVCF)** - A VCF Parser for Python. [ [web](http://pyvcf.readthedocs.org/en/latest/index.html) ]
+- **[ClawBio](https://github.com/ClawBio/ClawBio)** - Bioinformatics-native AI agent skill library. Local-first pharmacogenomics, ancestry PCA, semantic similarity, nutrigenomics, and metagenomics skills with reproducibility bundles. [ [web](https://clawbio.github.io/ClawBio) ]
 
 ### Assembly
 - **[SPAdes](https://github.com/ablab/spades)** - SPAdes (St. Petersburg genome assembler) is an assembly toolkit containing various assembly pipelines and the de-facto standard for prokaryotic genome assemblies.


### PR DESCRIPTION
## Summary

Add [ClawBio](https://github.com/ClawBio/ClawBio) to the **Python Modules > Tools** section.

ClawBio is a bioinformatics-native AI agent skill library built on [OpenClaw](https://github.com/open-claw/openclaw). It provides local-first, reproducible skills for:

- **Pharmacogenomics** (PharmGx) — DPWG/CPIC guideline lookup from personal VCFs
- **Ancestry PCA** — population-structure principal component analysis on 1000 Genomes + user data
- **Semantic Similarity** — PubMedBERT-powered disease-research coverage scoring across 13.1M PubMed abstracts and 175 GBD conditions
- **Nutrigenomics** — gene-nutrient interaction analysis (community-contributed)
- **Metagenomics** — 16S/shotgun microbiome profiling

Every skill ships with a reproducibility bundle (frozen environment, reference data checksums, deterministic outputs). The library was presented at the London Bioinformatics Meetup (Feb 2026) and is actively maintained.

- GitHub: https://github.com/ClawBio/ClawBio
- Docs / slides: https://clawbio.github.io/ClawBio