### PR TITLE
Add EOL API and Movebank to Database Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ The following tools can be used to visualize genomic data or for constructing cu
 
 ## Database Access
 
+- [Encyclopedia of Life (EOL) API](https://eol.org/docs/what-is-eol/open-api) - RESTful API providing programmatic access to species pages, taxonomy, traits, and media for over 2.7 million taxa aggregated from hundreds of biodiversity databases.
 - [Entrez Direct: E-utilities on the UNIX command line](http://www.ncbi.nlm.nih.gov/books/NBK179288/) - UNIX command line tools to access NCBI's databases programmatically. Instructions to install and examples are found in the link.
+- [Movebank Data Repository](https://www.movebank.org/cms/movebank-main) - Open repository of animal movement data from GPS and other tracking technologies, with a public API and over 3 billion location records across thousands of species.
 
 ## Resources
 


### PR DESCRIPTION
Expands the Database Access section with two widely-used biodiversity databases that have programmatic APIs:

- **[Encyclopedia of Life (EOL) API](https://eol.org/docs/what-is-eol/open-api)** — RESTful API for species taxonomy, traits, and media across 2.7 million taxa, aggregated from hundreds of biodiversity data sources. Useful for cross-referencing species identifiers and pulling trait data into bioinformatics pipelines.

- **[Movebank Data Repository](https://www.movebank.org/cms/movebank-main)** — Open repository and API for animal movement data from GPS and biologger deployments, with over 3 billion location records. Actively used in ecological and bioinformatics research for spatial analysis and movement modeling.

Both entries follow the existing section format and are in alphabetical order.