### PR TITLE
Add Scanpy to Python Modules / Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The following items allow for scalable genomic analysis by introducing specializ
 - **[pyfaidx](https://github.com/mdshw5/pyfaidx)** - Pythonic access to FASTA files.
 - **[pysam](https://github.com/pysam-developers/pysam)** - Python wrapper for [samtools](https://github.com/samtools/samtools). [ [web](https://pysam.readthedocs.io/en/latest/api.html) ]
 - **[pyVCF](https://github.com/jamescasbon/PyVCF)** - A VCF Parser for Python. [ [web](http://pyvcf.readthedocs.org/en/latest/index.html) ]
+- **[Scanpy](https://github.com/scverse/scanpy)** - Scalable toolkit for analyzing single-cell gene expression data, including preprocessing, visualization, clustering, and trajectory inference. [ [paper-2018](https://doi.org/10.1186/s13059-017-1382-0) | [web](https://scanpy.readthedocs.io) ]
 
 ### Assembly
 - **[SPAdes](https://github.com/ablab/spades)** - SPAdes (St. Petersburg genome assembler) is an assembly toolkit containing various assembly pipelines and the de-facto standard for prokaryotic genome assemblies.


### PR DESCRIPTION
Scanpy is the de facto standard Python toolkit for single-cell RNA-seq analysis (2.3k+ stars, 600+ citations). It provides preprocessing, clustering, trajectory inference, and publication-ready visualizations for single-cell gene expression data. Part of the scverse ecosystem.

Made with [Cursor](https://cursor.com)