### PR TITLE
Add ProteinFP: Protein Function Prediction and Drug Candidate Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,21 @@ Package suites gather software packages and installation tools for specific lang
 
 ## Protein Function & Drug Discovery
 
+## Protein Function & Drug Discovery
+
 * __[ProteinFP](https://github.com/wowcowdowjones/proteinFP2)__ - 
-  End-to-end protein function prediction and drug candidate design. 
-  Give it a UniProt ID, get back active sites, druggable pockets, 
-  EC classification, GO terms, PPI partners, and evolved drug 
-  candidate molecules. [ [PyPI](https://pypi.org/project/proteinfp/) ]
+  End-to-end protein function prediction and drug candidate design from 
+  a single UniProt ID. Runs 13+ modules covering AlphaFold structure 
+  retrieval, druggable pocket detection, allosteric site prediction, 
+  EC classification (~97% accuracy), GO term prediction, Foldseek 
+  structural analogs, PPI partners (STRING DB), and ESM-2 language 
+  model embeddings. Includes a therapy modality decision engine 
+  (small molecule / antibody / PROTAC / allosteric), de novo drug 
+  candidate generation via AutoDock Vina + RDKit, molecular dynamics 
+  (OpenMM), and a disease-aware GRN/scRNA-seq simulation pipeline 
+  with pharmacological scoring (efficacy, selectivity, resistance risk). 
+  Works on any protein from any organism.
+  [ __[PyPI](https://pypi.org/project/proteinfp/)__ ]
 
 ## Data Tools
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Package suites gather software packages and installation tools for specific lang
 - **[Biocaml](https://github.com/biocaml/biocaml)** - Biocaml aims to be a high-performance user-friendly library for Bioinformatics.
 - **[Biojava](https://github.com/biojava/biojava)** - Java framework for processing biological data.
 
+## Protein Function & Drug Discovery
+
+* __[ProteinFP](https://github.com/wowcowdowjones/proteinFP2)__ - 
+  End-to-end protein function prediction and drug candidate design. 
+  Give it a UniProt ID, get back active sites, druggable pockets, 
+  EC classification, GO terms, PPI partners, and evolved drug 
+  candidate molecules. [ [PyPI](https://pypi.org/project/proteinfp/) ]
+
 ## Data Tools
 
 ### Downloading

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Package suites gather software packages and installation tools for specific lang
 
 ## Protein Function & Drug Discovery
 
-* __[ProteinFP](https://github.com/wowcowdowjones/proteinFP2)__ - Give it a UniProt ID; get back active sites, druggable pockets, EC classification, GO terms, PPI partners, therapy modality recommendations, and evolved drug candidate molecules — for any protein, any organism. [ __[PyPI](https://pypi.org/project/proteinfp/)__ ]
+* __[ProteinFP](https://github.com/wowcowdowjones/proteinFP2)__ - Give it a UniProt ID; get back active sites, druggable pockets, EC classification, GO terms, PPI partners, therapy modality recommendations, and evolved drug candidate molecules, for any protein, any organism. [ __[PyPI](https://pypi.org/project/proteinfp/)__ ]
 
 ## Data Tools
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A curated list of awesome Bioinformatics software, resources, and libraries. Mos
 ## Table of Contents
 
 - [Package suites](#package-suites)
+- [Protein Function & Drug Discovery](#protein-function--drug-discovery)
 - [Data Tools](#data-tools)
   - [Downloading](#downloading)
   - [Compressing](#compressing)

--- a/README.md
+++ b/README.md
@@ -80,21 +80,7 @@ Package suites gather software packages and installation tools for specific lang
 
 ## Protein Function & Drug Discovery
 
-## Protein Function & Drug Discovery
-
-* __[ProteinFP](https://github.com/wowcowdowjones/proteinFP2)__ - 
-  End-to-end protein function prediction and drug candidate design from 
-  a single UniProt ID. Runs 13+ modules covering AlphaFold structure 
-  retrieval, druggable pocket detection, allosteric site prediction, 
-  EC classification (~97% accuracy), GO term prediction, Foldseek 
-  structural analogs, PPI partners (STRING DB), and ESM-2 language 
-  model embeddings. Includes a therapy modality decision engine 
-  (small molecule / antibody / PROTAC / allosteric), de novo drug 
-  candidate generation via AutoDock Vina + RDKit, molecular dynamics 
-  (OpenMM), and a disease-aware GRN/scRNA-seq simulation pipeline 
-  with pharmacological scoring (efficacy, selectivity, resistance risk). 
-  Works on any protein from any organism.
-  [ __[PyPI](https://pypi.org/project/proteinfp/)__ ]
+* __[ProteinFP](https://github.com/wowcowdowjones/proteinFP2)__ - Give it a UniProt ID; get back active sites, druggable pockets, EC classification, GO terms, PPI partners, therapy modality recommendations, and evolved drug candidate molecules — for any protein, any organism. [ __[PyPI](https://pypi.org/project/proteinfp/)__ ]
 
 ## Data Tools
 


### PR DESCRIPTION
ProteinFP fills a gap in this list, there's currently no tool covering 
end-to-end protein function prediction and drug candidate design. It takes 
a single UniProt ID and runs 13+ chained modules that allow researchers to 
predict protein function from multiple angles: AlphaFold structure retrieval, 
druggable pocket and allosteric site detection, EC classification (ML ensemble, 
~97% accuracy), GO term prediction, ESM-2 language model embeddings, Foldseek 
structural analogs, and PPI partners via STRING DB. From there, it can generate 
antibody epitope candidates and small molecules depending on the therapy modality 
decision engine, and with AutoDock Vina, evolved drug candidate molecules. A 
disease-aware mode adds scRNA-seq gene regulatory network reconstruction and 
whole-cell pharmacological simulation with efficacy, selectivity, and resistance 
risk scoring. It is open-source (MIT), pip-installable, works on any protein from 
any organism, and includes ready-to-use configs for LUAD, CRC, TB, and Leishmaniasis.

PyPI: [ProteinFP](https://pypi.org/project/proteinfp/)
GitHub: [ProteinFP](https://github.com/wowcowdowjones/proteinFP2)