### PR TITLE
Add peptide-qc sequence analysis toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Package suites gather software packages and installation tools for specific lang
 
 - **[Bioinformatics One Liners](https://github.com/stephenturner/oneliners)** - Git repo of useful single line commands.
 - **[BioNode](https://github.com/bionode/bionode)** - Modular and universal bioinformatics, Bionode provides pipeable UNIX command line tools and JavaScript APIs for bioinformatics analysis workflows. [ [web](http://bionode.io) ]
+- **[peptide-qc](https://github.com/PeptidoMexico/peptidomexico-open-science/tree/main/packages/peptide-qc)** - Dependency-free command-line and JavaScript tools for inspecting standard peptide sequences, composition, mass, approximate charge/pI and hydropathy. [ [web](https://peptidomexico.com.mx/calculadora/) ]
 - **[bioSyntax](https://github.com/bioSyntax/bioSyntax)** - Syntax Highlighting for Computational Biology file formats (SAM, VCF, GTF, FASTA, PDB, etc...) in vim/less/gedit/sublime. [ [paper-2018](https://pubmed.ncbi.nlm.nih.gov/30134911) | [web](http://www.bioSyntax.org) ]
 - **[CSVKit](https://github.com/wireservice/csvkit)** - Utilities for working with CSV/Tab-delimited files. [ [web](https://csvkit.readthedocs.io/en/latest) ]
 - **[csvtk](https://github.com/shenwei356/csvtk)** - Another cross-platform, efficient, practical and pretty CSV/TSV toolkit. [ [web](https://bioinf.shenwei.me/csvtk) ]


### PR DESCRIPTION
## Why this fits

`peptide-qc` is a small open-source command-line and JavaScript toolkit for a bioinformatics-adjacent sequence-analysis task: inspecting standard peptide sequences and producing deterministic composition, elemental formula, average/monoisotopic mass, approximate charge/pI and hydropathy reports.

It is dependency-free at runtime, has tests and explicit interpretation boundaries. The entry points to the source package and the working browser calculator so readers can inspect or use it.

- Source: https://github.com/PeptidoMexico/peptidomexico-open-science/tree/main/packages/peptide-qc
- Documentation: https://github.com/PeptidoMexico/peptidomexico-open-science/blob/main/docs/open-source/peptide-qc.md
- Web calculator: https://peptidomexico.com.mx/calculadora/
